### PR TITLE
Update 2020-06-12-outline-self-hosted-wiki.md

### DIFF
--- a/_posts/2020-06-12-outline-self-hosted-wiki.md
+++ b/_posts/2020-06-12-outline-self-hosted-wiki.md
@@ -19,7 +19,7 @@ Then, I found [outline](https://www.getoutline.com/)! Outline is similar to Tidd
 <span class="marginnote">
     Outline has great UI
 </span>
-<img src='https://www.getoutline.com/screenshot.png'>
+<img src='https://www.getoutline.com/images/screenshot.png'>
 
 
 Best part of all of this is that *data doesn't leave your servers* if you self-host it!


### PR DESCRIPTION
direct link to the outline screenshot image.
the image doesn't display on the blog itself but does in github,